### PR TITLE
Add license and Cloudsmith attribution

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,29 @@
+OpenNMS License
+===============
+
+This file is part of OpenNMS(R).
+
+Copyright (C) 2023 The OpenNMS Group, Inc.
+OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+
+OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+
+OpenNMS(R) is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License,
+or (at your option) any later version.
+
+OpenNMS(R) is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with OpenNMS(R).  If not, see:
+     http://www.gnu.org/licenses/
+
+For more information contact:
+    OpenNMS(R) Licensing <license@opennms.org>
+    http://www.opennms.org/
+    http://www.opennms.com/
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
-# api-contracts
-Repository containing cross project API contracts
+# API Contracts
+[![Hosted By: Cloudsmith](https://img.shields.io/badge/OSS%20hosting%20by-cloudsmith-blue?logo=cloudsmith&style=for-the-badge)](https://cloudsmith.com)
+
+Repository containing cross project API contracts.
+
+Package repository hosting is graciously provided by  [Cloudsmith](https://cloudsmith.com).
+Cloudsmith is the only fully hosted, cloud-native, universal package management solution, that
+enables your organization to create, store and share packages in any format, to any place, with total
+confidence.


### PR DESCRIPTION
GNU V3 license file was copied from here with updated dates: https://github.com/OpenNMS-Cloud/horizon-stream/blob/develop/LICENSE.md

Attribution for Cloudsmith was added to meet their [attribution rules for OSS.](https://help.cloudsmith.io/docs/open-source-hosting-policy#attribution)